### PR TITLE
Whitelisting Manual Interface

### DIFF
--- a/libs/binder/include/binder/IInterface.h
+++ b/libs/binder/include/binder/IInterface.h
@@ -247,6 +247,7 @@ constexpr const char* const kManualInterfaces[] = {
   "android.hardware.ISoundTriggerHwService",
   "android.hardware.IStreamListener",
   "android.hardware.IStreamSource",
+  "android.hardware.fingerprint.IFingerprintCustomDaemon",
   "android.input.IInputFlinger",
   "android.input.ISetInputWindowsListener",
   "android.media.IAudioFlinger",


### PR DESCRIPTION
-Whitelisting "IFingerprintCustomDaemon" as it is manual Interfaces.
-According to this : error: static_assert failed due to requirement 'internal::allowedManualInterface("android.hardware.fingerprint.IFingerprintCustomDaemon
")' . If an interface must be manually written, add its name to the whitelist.